### PR TITLE
Add dataset reliability audit script and docs for MeshGraphNet variants and data-generation validity

### DIFF
--- a/MESHGRAPHNET_VARIANTS.md
+++ b/MESHGRAPHNET_VARIANTS.md
@@ -1,0 +1,227 @@
+# MeshGraphNet 系・Neural Operator 系モデル候補メモ
+
+> 対象: H3 ペイロードフェアリング CFRP/Al-Honeycomb サンドイッチ構造の固定メッシュ SHM / 欠陥局在化。  
+> 最終更新: 2026-06-06。arXiv で 2026-06-06 時点の関連ページを確認。
+
+---
+
+## 1. このレポでの前提
+
+- 現行の実装は `src/train.py` から `--arch` を指定して GCN / GAT / GIN / GraphSAGE 系のノード分類を回す構成。
+- データは CFRP/Al-HC フェアリングをメッシュグラフ化し、ノードごとに応力・温度・曲率・法線などの特徴から欠陥/健全を分類するタスクが中心。
+- 直近の最適化対象は **「同じ/近い固定メッシュ上で、欠陥領域のノード分類 F1・Recall・境界精度を上げること」**。したがって、まずは既存 `train.py` に追加しやすい graph backbone を優先し、違う形状・違うメッシュ・連続場回帰へ進む段階で Neural Operator 系を本格化する。
+
+---
+
+## 2. ほかに試す価値がありそうなモデル
+
+| 候補 | 主な狙い | 固定 CFRP メッシュ分類との相性 | 実装難度 | 短期優先度 | このレポでの使いどころ |
+|---|---|---:|---:|---:|---|
+| **MeshGraphNet-Transformer (MGN-T)** | MGN の局所 message passing に Transformer 系の大域 processor を足して長距離依存を直接扱う | ★★★★★ | ★★★★☆ | **最優先** | センサ/欠陥/境界条件が離れているケース、フェアリング全周の相関、under-reaching 対策 |
+| **Transolver 系** | Physics-aware token / slice attention で不規則メッシュの PDE 的相関を線形に近い計算量で扱う | ★★★★★ | ★★★★☆ | **最優先** | 固定メッシュ上の応力・温度・曲率・異方性特徴から、遠方の物理状態をまとめて参照 |
+| **LinearNO / LANO 系** | Transolver の slice/deslice を linear attention として再整理し、軽量な operator block にする | ★★★★☆ | ★★★★☆ | 高 | MGN-T/Transolver が重い場合の軽量 attention processor 候補 |
+| **PGOT / GAOT 系** | geometry-aware operator transformer。境界・曲率・幾何埋め込みを明示的に保持 | ★★★★☆ | ★★★★★ | 中-高 | 曲率・境界条件・欠陥境界が精度ボトルネックになった後の発展候補 |
+| **X-MeshGraphNet** | partition + halo + multi-scale graph で大規模 mesh/point cloud を扱う | ★★★★☆ | ★★★★☆ | 高 | 10k ノードから 100k ノード級へ拡張、全フェアリング高解像度化、推論時の mesh 依存低減 |
+| **PIORF / physics-informed rewiring** | over-squashing bottleneck を物理量と Ollivier-Ricci curvature で rewiring | ★★★★☆ | ★★★☆☆ | 高 | 既存 GAT/GIN/SAGE に比較的小さく足せる長距離 edge augmentation |
+| **GINO** | Graph Neural Operator + FNO で任意形状/任意離散化の連続場 operator learning | ★★★☆☆ | ★★★★★ | 中 | 違う形状、違うメッシュ、連続場回帰、Abaqus 代替 surrogate へ拡張するとき |
+| **Graph Neural Operator (GNO)** | integral operator を graph message passing で近似し、離散化をまたぐ PDE surrogate を学習 | ★★★☆☆ | ★★★★☆ | 中 | 固定分類より、解演算子・解像度非依存 surrogate の基礎 |
+| **Equivariant GNN / EGNO** | 3D 回転・並進・ベクトル/テンソル量への物理整合性 | ★★★☆☆ | ★★★★☆ | 中 | 変位・速度・応力テンソルや時系列ダイナミクスを扱う段階で有望 |
+| **Graph Mamba / SSM processor** | O(N) に近い長距離依存、Transformer より軽い global context | ★★★★☆ | ★★★☆☆ | 高 | ノード数増大時に Transolver より実装を軽くしたい場合の代替 |
+
+### 短期方針
+
+CFRP 固定メッシュでは、まず **MeshGraphNet-Transformer** と **Transolver 系** を優先する。理由は次の 3 点。
+
+1. **欠陥局在は長距離依存を含む**: CFRP/Al-HC の界面剥離では、局所応力だけでなく境界条件、曲率、熱応力、センサ配置、異方性方向が離れた位置から効く。
+2. **既存のノード分類 API と相性がよい**: 既存の `train.py` はノード特徴 `x`、`edge_index`、`edge_attr`、ラベル `y` を使う構成なので、global processor を backbone として差し替えやすい。
+3. **operator learning より評価が早い**: GINO / GNO は本質的には連続場回帰・形状汎化で強い。固定メッシュ分類だけなら、まず MGN-T / Transolver / rewiring の ablation を行う方が短期の論文・実装成果に直結する。
+
+---
+
+## 3. Transolver 系のこのレポ向け整理
+
+### 3.1 physics-aware token / slice attention の意味
+
+Transolver は、各メッシュ点をそのまま全点 attention するのではなく、**似た物理状態の点を learnable slice に割り当て、slice から physics-aware token を作って attention する**発想である。CFRP フェアリングでは、同じ欠陥近傍・同じ温度勾配・同じ曲率帯・同じ繊維方向応答を持つノードを、幾何的に離れていても同じ物理 token としてまとめられる可能性がある。
+
+### 3.2 CFRP 固定メッシュで試す理由
+
+- **長距離依存**: 局所 message passing では到達に多層が必要な遠方ノードを、slice token 経由で短絡できる。
+- **異方性のクラスタリング**: CFRP の繊維方向、曲率、法線、熱応力などを入力特徴に含めると、単純な距離ではなく「物理状態の近さ」で attention できる。
+- **計算量**: 全ノード self-attention より軽くできるため、10k ノード級グラフの batch 学習に現実味がある。
+- **解釈性**: slice assignment を可視化すれば、欠陥境界・熱応力集中・曲率帯が別 token に分かれるかを確認できる。
+
+### 3.3 既存 `train.py` へ統合する際の確認事項
+
+| 確認項目 | 具体的な見るポイント |
+|---|---|
+| 入出力 shape | 既存モデルと同じく `data.x`, `data.edge_index`, `data.edge_attr`, `data.batch` を受け、ノード logits `(num_nodes, num_classes)` を返す。 |
+| batching | PyG の複数 graph batch で slice attention が graph 間に漏れないよう、`batch` ごとに attention mask または graph-wise pooling を使う。 |
+| edge_attr の扱い | Transolver 本体は点 token 寄りなので、edge_attr は MGN encoder や edge bias として残す。edge を捨てると既存メッシュ物理の利点を失う。 |
+| 座標/幾何特徴 | `pos` がないデータでは、node feature 内の座標・法線・曲率 index を明示し、geometry MLP に入れる。 |
+| class imbalance | 現行の focal loss、boundary-aware weighting、defect-centric sampler はそのまま比較に残す。backbone だけを変える ablation にする。 |
+| 評価指標 | node F1 だけでなく defect Recall、境界 IoU、connected-component 単位の検出率、校正誤差を追加する。 |
+| 可視化 | slice assignment / attention heatmap を欠陥 mask・曲率・温度・応力と重ねる。 |
+
+### 3.4 Transolver 系の注意点
+
+2025--2026 年の後続研究では、Transolver の効果は slice attention そのものより **slice/deslice 変換と linear attention 的な構造**に由来する可能性が指摘されている。したがって実装順は、(1) slice-token Transolver、(2) slice attention を簡略化した LinearNO 風 block、(3) MGN-T global processor、の 3 系統を同条件で比較するのがよい。
+
+---
+
+## 4. 2026-06 時点で追加で見るべき「最新寄り」アイデア
+
+| 新しめの候補 | 何が新しいか | このレポへの仮説 | 優先実験 |
+|---|---|---|---|
+| **MGN-T (2026)** | MeshGraphNet の inductive bias を保ったまま global Transformer processor を使う | 固定メッシュ分類では GAT より境界条件・遠方欠陥の取り込みが強いはず | `--arch mgn_tiny` として hidden 64/128、global heads 4、local MGN 2層 + global 2層 |
+| **PGOT (2025/2026)** | physics slicing に geometry injection と geometry aliasing 対策を入れる | 曲率・境界・欠陥端での誤分類を減らせる可能性 | 欠陥境界ノードだけの F1/IoU を主要指標に追加 |
+| **LinearNO / LANO (2025/2026)** | physics attention をより軽い linear attention operator にする | 10k ノード級の GPU メモリを抑えつつ Transolver 近い長距離依存を得る | Transolver block の attention 部だけ差し替え可能な実装にする |
+| **PIORF rewiring (2025)** | 物理量で長距離 edge を追加し over-squashing を減らす | 既存 GAT/GIN/SAGE の強化として最も安い。欠陥境界から遠方 sensor/BC への edge が効くか検証 | 前処理で stress/temperature/fiber 類似 top-k edge を追加する ablation |
+| **GAOT (2025/2026)** | geometry-aware encoder/decoder + Transformer processor | GINO より Transformer 寄りで、将来の連続場 surrogate に移行しやすい | まず wave/stress field 回帰 dataset が揃ってから |
+| **X-MeshGraphNet (2024)** | partition + halo + multi-scale point graph | 全周高解像度 mesh や STL からの推論では強い | 現行 10k graph ではなく、100k node 以上のロードマップ用 |
+
+### 最短で成果を出すための実験順
+
+1. **Baseline 固定**: 既存 GAT / GIN / SAGE を同じ seed、同じ sampler、同じ focal loss で再計測。
+2. **PIORF 風 rewiring**: 実装が軽いので、追加 edge の効果を先に見る。改善すれば「長距離 edge が効く」という仮説を確認できる。
+3. **MGN-Tiny**: local MGN encoder + 低層 global attention processor + node decoder。最もレポの `MeshGraphNet` 文脈と整合。
+4. **Transolver-Tiny**: node を slice token に圧縮して global context を入れる。MGN-T と同等 parameter budget で比較。
+5. **LinearNO/PGOT 要素**: Transolver が効く場合だけ、軽量化・geometry injection を追加する。
+6. **GINO/GNO**: 固定分類ではなく、Abaqus 代替の連続場 surrogate、メッシュ解像度変更、形状違いへ移る段階で本格実装。
+
+---
+
+## 5. GINO / Graph Neural Operator の位置づけ
+
+GINO と Graph Neural Operator は、**固定メッシュ分類を少し改善するための第一候補ではない**。むしろ次の拡張で有望である。
+
+- **違うメッシュ**: 粗密や要素分割が違っても同じ operator として推論したい。
+- **違う形状**: 平板、円筒、フェアリング ogive、局所補強部など形状をまたぐ。
+- **連続場回帰**: 欠陥ラベルだけでなく、変位場、応力場、温度場、ガイド波場を直接予測する。
+- **operator learning**: 荷重条件・境界条件・欠陥 mask から場全体への写像を学び、Abaqus / FEM を surrogate 化する。
+- **データ生成高速化**: 欠陥パラメータ sweep を高速化し、GNN 分類器の augmentation に使う。
+
+固定メッシュ分類の短期ゴールでは、GINO/GNO は「将来の surrogate backbone」として文献・設計を押さえ、現時点の優先実装は MGN-T / Transolver / rewiring に寄せる。
+
+---
+
+## 6. 参考文献
+
+- MeshGraphNet-Transformer: Scalable Mesh-based Learned Simulation for Solid Mechanics, arXiv:2601.23177, 2026. https://arxiv.org/abs/2601.23177
+- Transolver: A Fast Transformer Solver for PDEs on General Geometries, arXiv:2402.02366, 2024. https://arxiv.org/abs/2402.02366
+- Transolver is a Linear Transformer: Revisiting Physics-Attention through the Lens of Linear Attention, arXiv:2511.06294, 2025/2026. https://arxiv.org/abs/2511.06294
+- PGOT: A Physics-Geometry Operator Transformer for Complex PDEs, arXiv:2512.23192, 2025/2026. https://arxiv.org/abs/2512.23192
+- PIORF: Physics-Informed Ollivier-Ricci Flow for Long-Range Interactions in Mesh Graph Neural Networks, arXiv:2504.04052, 2025. https://arxiv.org/abs/2504.04052
+- Geometry Aware Operator Transformer as an Efficient and Accurate Neural Surrogate for PDEs on Arbitrary Domains, arXiv:2505.18781, 2025/2026. https://arxiv.org/abs/2505.18781
+- X-MeshGraphNet: Scalable Multi-Scale Graph Neural Networks for Physics Simulation, arXiv:2411.17164, 2024. https://arxiv.org/abs/2411.17164
+- Geometry-Informed Neural Operator for Large-Scale 3D PDEs, arXiv:2309.00583, 2023. https://arxiv.org/abs/2309.00583
+- Neural Operator: Graph Kernel Network for Partial Differential Equations, arXiv:2003.03485, 2020. https://arxiv.org/abs/2003.03485
+- Neural Operator: Learning Maps Between Function Spaces, arXiv:2108.08481 / JMLR 2023, revised 2024. https://arxiv.org/abs/2108.08481
+- Equivariant Graph Neural Operator for Modeling 3D Dynamics, arXiv:2401.11037 / ICML 2024. https://arxiv.org/abs/2401.11037
+
+---
+
+## 7. BibTeX
+
+```bibtex
+@misc{iparraguirre2026meshgraphnettransformer,
+  title={MeshGraphNet-Transformer: Scalable Mesh-based Learned Simulation for Solid Mechanics},
+  author={Mikel M. Iparraguirre and Iciar Alfaro and David Gonzalez and Elias Cueto},
+  year={2026},
+  eprint={2601.23177},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{wu2024transolver,
+  title={Transolver: A Fast Transformer Solver for PDEs on General Geometries},
+  author={Haixu Wu and Huakun Luo and Haowen Wang and Jianmin Wang and Mingsheng Long},
+  year={2024},
+  eprint={2402.02366},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{hu2025transolverlinear,
+  title={Transolver is a Linear Transformer: Revisiting Physics-Attention through the Lens of Linear Attention},
+  author={Wenjie Hu and Sidun Liu and Peng Qiao and Zhenglun Sun and Yong Dou},
+  year={2025},
+  eprint={2511.06294},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{zhang2025pgot,
+  title={PGOT: A Physics-Geometry Operator Transformer for Complex PDEs},
+  author={Zhuo Zhang and Xi Yang and Ying Miao and Xiaobin Hu and Yifu Gao and Yuan Zhao and Yong Yang and Canqun Yang and Boocheong Khoo},
+  year={2025},
+  eprint={2512.23192},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{yu2025piorf,
+  title={PIORF: Physics-Informed Ollivier-Ricci Flow for Long-Range Interactions in Mesh Graph Neural Networks},
+  author={Youn-Yeol Yu and Jeongwhan Choi and Jaehyeon Park and Kookjin Lee and Noseong Park},
+  year={2025},
+  eprint={2504.04052},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{wen2025gaot,
+  title={Geometry Aware Operator Transformer as an Efficient and Accurate Neural Surrogate for PDEs on Arbitrary Domains},
+  author={Shizheng Wen and Arsh Kumbhat and Levi Lingsch and Sepehr Mousavi and Yizhou Zhao and Praveen Chandrashekar and Siddhartha Mishra},
+  year={2025},
+  eprint={2505.18781},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{nabian2024xmeshgraphnet,
+  title={X-MeshGraphNet: Scalable Multi-Scale Graph Neural Networks for Physics Simulation},
+  author={Mohammad Amin Nabian and Chang Liu and Rishikesh Ranade and Sanjay Choudhry},
+  year={2024},
+  eprint={2411.17164},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{li2023gino,
+  title={Geometry-Informed Neural Operator for Large-Scale 3D PDEs},
+  author={Zongyi Li and Nikola Borislavov Kovachki and Chris Choy and Boyi Li and Jean Kossaifi and Shourya Prakash Otta and Mohammad Amin Nabian and Maximilian Stadler and Christian Hundt and Kamyar Azizzadenesheli and Anima Anandkumar},
+  year={2023},
+  eprint={2309.00583},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{li2020graphkerneloperator,
+  title={Neural Operator: Graph Kernel Network for Partial Differential Equations},
+  author={Zongyi Li and Nikola Kovachki and Kamyar Azizzadenesheli and Burigede Liu and Kaushik Bhattacharya and Andrew Stuart and Anima Anandkumar},
+  year={2020},
+  eprint={2003.03485},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@article{kovachki2023neuraloperator,
+  title={Neural Operator: Learning Maps Between Function Spaces},
+  author={Nikola Kovachki and Zongyi Li and Burigede Liu and Kamyar Azizzadenesheli and Kaushik Bhattacharya and Andrew Stuart and Anima Anandkumar},
+  journal={Journal of Machine Learning Research},
+  volume={24},
+  number={89},
+  pages={1--97},
+  year={2023},
+  note={arXiv:2108.08481}
+}
+
+@misc{xu2024egno,
+  title={Equivariant Graph Neural Operator for Modeling 3D Dynamics},
+  author={Minkai Xu and Jiaqi Han and Aaron Lou and Jean Kossaifi and Arvind Ramanathan and Kamyar Azizzadenesheli and Jure Leskovec and Stefano Ermon and Anima Anandkumar},
+  year={2024},
+  eprint={2401.11037},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+```

--- a/docs/DATA_GENERATION_VALIDITY_RESEARCH.md
+++ b/docs/DATA_GENERATION_VALIDITY_RESEARCH.md
@@ -1,0 +1,256 @@
+# データ生成・データセット信頼性・関連研究の徹底調査
+
+> 作成日: 2026-06-06
+> 対象: H3 フェアリング CFRP/Al-Honeycomb SHM / FEM → Graph → GNN パイプライン
+> 目的: データ生成方法、データの正当性、データセット信頼性、外部データ・関連研究との接続、今後の予定を一本化する。
+
+---
+
+## 0. 結論サマリ
+
+現時点の最重要課題は、モデルを増やす前に **「学習に使うデータが物理的・数値的・統計的に信用できる状態か」** を定量監査することである。特にこのレポでは、以下を短期の意思決定として推奨する。
+
+1. **データ生成は `DOE → Abaqus FEM → ODB抽出 → CSV → graph化 → ML split` の各段階で gate を置く。** 生成に成功したかではなく、各 sample が必要 schema、非ゼロ物理量、欠陥ノード数、metadata 整合、mesh 解像度、ラベル分布を満たすかで採否を決める。
+2. **現在 checkout されている小規模サンプルは、研究用 benchmark としてはまだ弱い。** `dataset_output` は 2 sample・2 schema 混在・欠陥ノード 1 個のみ、`dataset_realistic` は 2 sample とも healthy label であり、モデル比較や論文の主結果には使わず、パイプライン動作確認用として扱う。
+3. **信頼性の主軸は V&V + UQ + 外部実験データ照合。** ASME V&V 10 / NASA-STD-7009A 的な「計算モデルの信用性」観点を採用し、mesh convergence、zero-physics 検出、healthy baseline、既知の外部 CFRP guided-wave dataset との cross-check を追加する。
+4. **外部 validation は Open Guided Waves #4 と NASA CFRP が最優先。** OGW #4 は CFRP plate + omega stringer + fully bonded / local debond / large debond の full wavefield dataset で、本レポの CFRP debonding SHM に最も近い公開 dataset である。NASA CFRP は run-to-failure fatigue、16 PZT、strain gauge、X-ray ground truth を含むため、sim-to-real と損傷進展 validation に使える。
+5. **今後の予定は「100%正しい synthetic dataset」ではなく、credibility score を上げる計画にする。** Phase 1 は strict extraction と schema 統一、Phase 2 は mesh/defect 分解能と DOE coverage、Phase 3 は OGW/NASA で cross-domain validation、Phase 4 は MAPOD/UQ に接続する。
+
+---
+
+## 1. このレポのデータ生成パイプライン
+
+### 1.1 生成フロー
+
+```mermaid
+flowchart LR
+    DOE[DOE: defect type / theta / z / radius]
+    FEM[Abaqus FEM: H3 fairing CFRP/Al-HC]
+    ODB[ODB: U / NT / S / strain]
+    CSV[CSV: nodes.csv / elements.csv / metadata.csv]
+    GRAPH[PyG graph: curvature / normal / physics features]
+    ML[train.py: node classification]
+
+    DOE --> FEM --> ODB --> CSV --> GRAPH --> ML
+```
+
+### 1.2 各段階で保存・検証すべき evidence
+
+| 段階 | 主な生成物 | 最低限の検証 | 採否 gate |
+|---|---|---|---|
+| DOE | `doe_*.json` | seed、分布、欠陥 type、radius tier、opening overlap rejection | 位置・半径・type が設計範囲内 |
+| FEM input | `.inp` | thermal patch、材料、境界条件、tie/contact、mesh seed | 想定 step と field output が含まれる |
+| Abaqus solve | `.odb`, `.dat`, `.msg`, `.sta` | job completed、increment convergence、warning/error 数 | ODB に解析 step と frame が存在 |
+| ODB extraction | `nodes.csv`, `elements.csv`, `metadata.csv` | schema、U/NT/S/LE の存在、非ゼロ物理量 | strict check pass |
+| graph化 | `train.pt`, `val.pt`, `norm_stats.pt` | feature dim、label count、edge count、normal/curvature range | NaN/Inf なし、ラベル/feature 整合 |
+| ML split | split metadata | sample-level split、class balance、healthy/defect separation | leakage なし、seed 固定 |
+
+---
+
+## 2. リポジトリ実装から見た現在の生成方法
+
+### 2.1 DOE と欠陥パラメータ
+
+`src/generate_doe.py` は複数欠陥 type と size tier を持つ層化 DOE を生成する。欠陥 type は `debonding`, `fod`, `impact`, `delamination`, `inner_debond`, `thermal_progression`, `acoustic_fatigue` の 7 種で、type fraction も定義されている。位置は `theta_deg` と `z_center`、サイズは `radius` で与え、opening overlap rejection も持つ。
+
+**現時点の注意:** `docs/DEFECT_PLAN.md` では Small=20--50 mm, Medium=50--80 mm, Large=80--150 mm, Critical=150--250 mm だが、`src/generate_doe.py` の現在の `SIZE_TIERS` は Small=50--100, Medium=100--150, Large=150--250, Critical=250--400 mm になっている。これは「50 mm mesh で欠陥を確実に複数 node で表す」方向には妥当だが、過去 doc と数値がズレているため、今後は **DOE version** と **mesh seed version** を metadata に残すべきである。
+
+### 2.2 ODB 抽出と label 生成
+
+`src/extract_odb_results.py` は ODB から outer skin instance を選び、最終 frame の変位 `U`、温度 `NT11/NT`、応力 `S`、任意の strain `LE/E` を抽出する。欠陥 label は円筒面上の geodesic-like distance、すなわち周方向 arc length と軸方向距離の合成距離が `radius` 以下なら `defect_label` を付ける。
+
+重要なのは `--strict` である。strict mode は全変位がゼロかつ温度変化がないケースを失敗扱いにし、thermal/load の欠落を検出する。これは過去に `dataset_output_100` や `dataset_output_25mm_400` で全物理量ゼロ問題が出ていたため、今後の標準実行では必須にする。
+
+### 2.3 Graph 化
+
+`src/build_graph.py` の `build_curvature_graph` は node feature として座標、normal、principal curvature、変位、温度、応力、thermal stress、strain、CFRP 繊維方向、layup angle、周方向角、boundary/loading flag をまとめる。edge feature は相対座標、Euclidean distance、normal angle、任意の geodesic distance である。
+
+**信頼性上のポイント:** graph 化関数は足りない物理列をゼロ埋めするため、schema 欠落があっても `train.py` まで進んでしまう。これは実験を止めない利点がある一方、**ゼロ埋め dataset を正常 dataset と誤認する危険** がある。したがって CSV → graph の前に `scripts/audit_dataset_reliability.py` を gate として走らせる。
+
+---
+
+## 3. 現在 checkout で実行したデータセット監査
+
+今回、依存関係なしで走る `scripts/audit_dataset_reliability.py` を追加した。`nodes.csv`, `elements.csv`, `metadata.csv` を走査し、schema、物理列、非ゼロ性、label count、metadata 整合、sample 数を確認する。
+
+実行結果:
+
+```bash
+python scripts/audit_dataset_reliability.py dataset_output dataset_realistic --json /tmp/dataset_audit.json
+```
+
+| Dataset | Samples | Nodes | Defect nodes | Node schemas | Warnings | 判断 |
+|---|---:|---:|---:|---:|---:|---|
+| `dataset_output` | 2 | 33,117 | 1 | 2 | 2 | **パイプライン例示用。学習 benchmark には不足** |
+| `dataset_realistic` | 2 | 83,519 | 0 | 1 | 0 | **healthy geometry/physics の例示用。欠陥分類には使えない** |
+
+### 3.1 `dataset_output` の問題
+
+| Sample | 監査結果 | リスク |
+|---|---|---|
+| `healthy_baseline` | displacement 列なし。stress / `dspss` は存在。 | sample_0001 と schema が違うため、graph feature のゼロ埋めが発生する。 |
+| `sample_0001` | stress-equivalent 列なし。欠陥 label は 1 node のみ。 | README の「77 欠陥ノード」説明とも合わず、学習には欠陥分解能が低すぎる。 |
+
+### 3.2 `dataset_realistic` の状態
+
+`dataset_realistic/phase1` と `phase2` は変位・温度・応力が非ゼロで、schema は揃っている。一方、metadata も label も healthy であり、欠陥ノードは 0 である。したがって、healthy baseline、mesh/geometry validation、物理量 sanity check には有用だが、欠陥分類性能の主張には使えない。
+
+### 3.3 過去診断との接続
+
+既存の `docs/DATASET_DIAGNOSIS_REPORT.md` では、`dataset_output_100` と `dataset_output_25mm_400` に全物理量ゼロ問題が報告されている。この教訓から、今後は **「ファイルがある」ではなく「物理量が非ゼロで、schema が揃い、欠陥ノードが mesh 分解能に対して十分ある」** を dataset 完成条件にする。
+
+---
+
+## 4. データセット信頼性の評価軸
+
+### 4.1 信頼性チェックリスト
+
+| 軸 | 合格条件 | 現状 | 次アクション |
+|---|---|---|---|
+| Provenance | DOE seed、code commit、Abaqus version、material version、mesh seed が trace 可能 | 部分的 | `metadata.csv` を sample manifest へ拡張 |
+| Schema | 全 sample が同一 node/element schema | `dataset_output` は NG | 旧 schema sample を再抽出または隔離 |
+| Physics non-zero | U/NT/S/LE のうち必要列が非ゼロ | 既存診断で NG 例あり | `--strict` と audit を CI gate 化 |
+| Label validity | metadata の defect type / radius と label count が整合 | `sample_0001` は欠陥 1 node | mesh seed と radius tier を再設計 |
+| Mesh resolution | 欠陥直径に対し十分な node 数 | 不十分 sample あり | defect nodes の下限を設定 |
+| Numerical V&V | mesh convergence、energy balance、境界条件 sanity | 部分的 | verification report を dataset manifest に接続 |
+| Statistical coverage | theta/z/r/type が偏らない | DOE はある | coverage plot と minimum bin count を保存 |
+| External validation | OGW/NASA など実験 dataset で傾向確認 | 未完 | cross-dataset benchmark を設計 |
+| UQ/reliability | POD/PFA、calibration、OOD/uncertainty | 部分的 | MAPOD + Bayesian/UQ 評価を追加 |
+
+### 4.2 defect node 数の下限案
+
+固定 mesh の node classification では、欠陥領域が 1--2 node だけだと F1/Recall が不安定になり、境界 IoU も意味を持ちにくい。短期 benchmark では以下を gate にする。
+
+| 目的 | 最低 defect nodes/sample | 理由 |
+|---|---:|---|
+| パイプライン smoke | 1 | label 生成だけ確認 |
+| 初期学習 | 30 | class imbalance が極端すぎない最低限 |
+| 論文用 benchmark | 100 | node-level F1、boundary error、component detection を安定評価 |
+| 境界 IoU / sizing | 300 | 欠陥境界形状・サイズ推定まで評価可能 |
+
+---
+
+## 5. 関連研究・外部データセット調査
+
+### 5.1 Open Guided Waves #4: CFRP omega stringer debonding
+
+[Zenodo record 5105861](https://zenodo.org/records/5105861) は CFRP plate + omega stringer の full ultrasonic guided wavefield dataset で、fully bonded、local stringer debond、large stringer debond の 3 scenario を含む。20--500 kHz chirp と 16.5/50/100/200/300 kHz tone-burst が使われ、defect は backside impact で作り、conventional ultrasound で検証されている。これは本レポの CFRP/Al-HC debonding SHM と完全一致ではないが、**CFRP 接着/剥離、guided wave、実験 ground truth** の 3 点が近いため、外部 validation の第一候補である。
+
+使い方:
+
+- FEM/graph model の欠陥 heatmap と、OGW wavefield から作る damage index / tomography map の空間傾向を比較。
+- まずは分類器を直接適用するのではなく、feature extractor / anomaly score の transfer を見る。
+- 周波数依存、温度一定、stringer 形状差を domain gap として明示する。
+
+### 5.2 NASA CFRP Composites dataset
+
+[NASA PCoE CFRP Composites dataset](https://www.nasa.gov/intelligent-systems-division/discovery-and-systems-health/pcoe/pcoe-data-set-repository/) は CFRP panel の run-to-failure tension-tension fatigue 実験で、16 個の PZT sensor の Lamb wave 信号、複数 triaxial strain gage、周期的 X-ray ground truth を含む。これは本レポの「単発欠陥局在」よりも「損傷進展・寿命・sim-to-real」に近い。
+
+使い方:
+
+- FEM-generated 欠陥 size/severity と NASA X-ray damage growth の単調性・進展パターンを比較。
+- 16 PZT sensor graph を作り、mesh graph から sensor graph への distillation / transfer を試す。
+- 将来的な remaining useful life / prognosis と接続する。
+
+### 5.3 長期 SHM dataset と環境変動
+
+2025 年の公開 guided-wave long-term SHM dataset では、構造・材料・センサ・取得装置・環境条件の違いにより手法比較が難しいこと、reversible damage model と tomographic image reconstruction による validation が重要であることが強調されている。これは、本レポで synthetic FEM dataset だけを見ると過大評価になりやすいことを示す。
+
+対応方針:
+
+- 温度、ノイズ、センサばらつき、接着ばらつき、境界条件ばらつきを DOE に入れる。
+- healthy baseline の seasonal / environmental variation を明示的に作る。
+- model は accuracy だけでなく calibration、false alarm、OOD を評価する。
+
+### 5.4 V&V / simulation credibility
+
+[ASME V&V 10](https://www.asme.org/codes-standards/find-codes-standards/standard-for-verification-and-validation-in-computational-solid-mechanics) は computational solid mechanics の V&V/UQ を通じて model credibility を高めるための標準である。[NASA-STD-7009A](https://standards.nasa.gov/standard/nasa/nasa-std-7009) は modeling and simulation に uniform practices、acceptance criteria、credibility assessment を求める。したがって、本レポの synthetic FEM dataset は「Abaqus で作ったから正しい」ではなく、verification, validation, uncertainty quantification, reporting の evidence を dataset に添付する必要がある。
+
+### 5.5 MAPOD / SHM reliability
+
+Guided-wave SHM では、単なる分類 accuracy より、Probability of Detection (POD)、Probability of False Alarm (PFA)、localization accuracy を不確かさ込みで評価する流れがある。[Yue and Aliabadi 2021](https://journals.sagepub.com/doi/abs/10.1177/1475921720940642) は guided-wave SHM の hierarchical reliability assessment として sensor placement、noise-based threshold、damage detection/localization performance を段階的に評価している。さらに guided-wave SHM で Model-Assisted POD (MAPOD) を使う研究も進んでいる。
+
+本レポでは、最終的に GNN の node F1 だけでなく、次の指標に移るべきである。
+
+- POD vs defect radius / depth / type
+- PFA under healthy + environmental variation
+- localization error in mm / degrees
+- sizing error for connected component area
+- calibration curve / expected calibration error
+- epistemic uncertainty for out-of-distribution geometry or defect type
+
+---
+
+## 6. 今後の予定に接続するロードマップ
+
+### Phase A: すぐやる dataset gate（1--2週間）
+
+- `scripts/audit_dataset_reliability.py` を dataset 生成後に必ず実行する。
+- `run_batch.py --strict` / `extract_odb_results.py --strict` を標準化する。
+- `dataset_output` の旧 schema sample と README mismatch を修正または「legacy example」として隔離する。
+- sample manifest を追加し、commit hash、DOE file、Abaqus version、mesh seed、material version、strict/audit result を保存する。
+
+合格基準:
+
+- 全 sample が同一 schema。
+- defect sample の `n_defect_nodes >= 30`、論文用 subset は `>=100`。
+- U/NT/S の必要列が非ゼロで NaN/Inf なし。
+- healthy と defect が sample-level split され、同一 DOE から train/val に leakage しない。
+
+### Phase B: 数値 V&V と mesh/DOE 妥当性（2--4週間）
+
+- mesh seed 50 mm / 25 mm / 12 mm の convergence を、欠陥 node count、最大応力、変位、connected component area で評価する。
+- DOE coverage plot を自動保存する。
+- defect radius tier と mesh seed の組み合わせを固定し、minimum resolvable defect を明記する。
+- healthy baseline は複数 seed / 温度 / load case で作る。
+
+合格基準:
+
+- mesh refinement に対し主要 QoI の変化が許容範囲内。
+- 各 radius/type bin に最低 sample 数がある。
+- zero-physics sample が 0。
+
+### Phase C: 外部 dataset validation（1--2か月）
+
+- OGW #4 を最優先で取り込み、CFRP debonding の実験 wavefield と synthetic FEM/graph feature の差を整理する。
+- NASA CFRP は sensor graph / fatigue progression / X-ray ground truth として使う。
+- 直接 accuracy ではなく、domain adaptation 前後の anomaly AUROC、feature embedding 分離、damage severity monotonicity を見る。
+
+合格基準:
+
+- 少なくとも 1 つの外部 CFRP dataset で healthy vs damaged の anomaly score が有意に分離する。
+- synthetic-only model の失敗例と domain gap を明示できる。
+
+### Phase D: Reliability metric / MAPOD / UQ（2--4か月）
+
+- POD curve を defect radius / type / sensor density / noise level ごとに作る。
+- Bayesian / ensemble / conformal prediction で uncertainty map を出す。
+- false alarm を healthy environmental variation で測る。
+- 論文では node F1 だけでなく POD/PFA/localization/sizing/calibration を主指標にする。
+
+---
+
+## 7. 参考文献・関連リンク
+
+### Public datasets
+
+1. Kudela et al., **Dataset on full ultrasonic guided wavefield measurements of a CFRP plate with fully bonded and partially debonded omega stringer**, Zenodo, 2021 / Data in Brief 2022. https://zenodo.org/records/5105861
+2. NASA Ames PCoE, **Carbon Fiber-Reinforced Polymer (CFRP) Composites dataset**, NASA Prognostics Data Repository. https://www.nasa.gov/intelligent-systems-division/discovery-and-systems-health/pcoe/pcoe-data-set-repository/
+3. Dataset on guided waves from long-term SHM under uncontrolled and dynamic conditions, 2025. https://pmc.ncbi.nlm.nih.gov/articles/PMC12162875/
+
+### V&V / credibility / reliability
+
+4. ASME, **V&V 10 - Standard for Verification and Validation in Computational Solid Mechanics**, 2019, reaffirmed/stabilized 2025. https://www.asme.org/codes-standards/find-codes-standards/standard-for-verification-and-validation-in-computational-solid-mechanics
+5. NASA, **NASA-STD-7009A Standard for Models and Simulations**. https://standards.nasa.gov/standard/nasa/nasa-std-7009
+6. Yue and Aliabadi, **Hierarchical approach for uncertainty quantification and reliability assessment of guided wave-based structural health monitoring**, Structural Health Monitoring, 2021. https://journals.sagepub.com/doi/abs/10.1177/1475921720940642
+7. Application of Model Assisted Probability of Detection (MAPOD) to a Guided Wave SHM System, SHM 2017. https://dpi-proceedings.com/index.php/shm2017/article/view/14038
+8. Model Assisted Probability of Detection for Guided Wave Imaging SHM, SHM 2019. https://www.dpi-proceedings.com/index.php/shm2019/article/view/32190
+
+### Repo-internal documents to keep aligned
+
+- `docs/DATASET_DIAGNOSIS_REPORT.md`: 過去の zero-physics / schema mismatch 診断。
+- `docs/DEFECT_PLAN.md`: 欠陥 type、サイズ階層、DOE 設計。
+- `docs/MESH_DEFECT_ANALYSIS.md`: mesh seed と欠陥分解能。
+- `docs/VERIFICATION_REPORT.md`: 生成結果の verification evidence。
+- `docs/PUBLIC_DATASETS_AND_INTEGRATION.md`: OGW / NASA など外部 dataset 統合。
+- `docs/NOISE_AUGMENTATION_AND_CLASS_RATIO.md`: noise augmentation と class imbalance。

--- a/scripts/audit_dataset_reliability.py
+++ b/scripts/audit_dataset_reliability.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Audit generated FEM/graph CSV datasets for SHM dataset reliability.
+
+This script is intentionally dependency-light (standard library only) so it can
+run in minimal CI environments without Abaqus, pandas, torch, or PyG.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+REQUIRED_NODE_COLUMNS = {"node_id", "x", "y", "z", "defect_label"}
+PHYSICS_COLUMNS = [
+    "ux",
+    "uy",
+    "uz",
+    "u_mag",
+    "temp",
+    "s11",
+    "s22",
+    "s12",
+    "smises",
+    "dspss",
+    "thermal_smises",
+    "le11",
+    "le22",
+    "le12",
+]
+DISPLACEMENT_COLUMNS = ["ux", "uy", "uz", "u_mag"]
+STRESS_COLUMNS = ["s11", "s22", "s12", "smises", "dspss", "thermal_smises"]
+ELEMENT_COLUMNS = {"elem_id", "n1", "n2", "n3"}
+
+
+def _safe_float(value: str) -> float:
+    if value is None or value == "":
+        return 0.0
+    return float(value)
+
+
+def _discover_sample_dirs(root: Path) -> List[Path]:
+    sample_dirs: List[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        path = Path(dirpath)
+        if "nodes.csv" in filenames:
+            sample_dirs.append(path)
+            dirnames[:] = []
+    return sorted(sample_dirs)
+
+
+def _read_metadata(sample_dir: Path) -> Dict[str, str]:
+    path = sample_dir / "metadata.csv"
+    if not path.exists():
+        return {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        rows = list(reader)
+    if rows and rows[0] == ["key", "value"]:
+        return {row[0]: row[1] for row in rows[1:] if len(row) >= 2}
+    return {}
+
+
+def _count_elements(sample_dir: Path) -> Tuple[int, List[str], List[str]]:
+    path = sample_dir / "elements.csv"
+    if not path.exists():
+        return 0, [], ["missing elements.csv"]
+    warnings: List[str] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        columns = reader.fieldnames or []
+        missing = sorted(ELEMENT_COLUMNS - set(columns))
+        if missing:
+            warnings.append("elements.csv missing columns: " + ",".join(missing))
+        count = sum(1 for _ in reader)
+    return count, columns, warnings
+
+
+def _audit_nodes(sample_dir: Path) -> Dict[str, object]:
+    path = sample_dir / "nodes.csv"
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        columns = reader.fieldnames or []
+        missing_required = sorted(REQUIRED_NODE_COLUMNS - set(columns))
+        present_physics = [c for c in PHYSICS_COLUMNS if c in columns]
+        present_displacement = [c for c in DISPLACEMENT_COLUMNS if c in columns]
+        present_stress = [c for c in STRESS_COLUMNS if c in columns]
+
+        n_nodes = 0
+        labels: Counter[str] = Counter()
+        nonzero_counts: Counter[str] = Counter()
+        maxima: Dict[str, float] = {}
+        minima: Dict[str, float] = {}
+        coordinate_bounds = {
+            "x": [math.inf, -math.inf],
+            "y": [math.inf, -math.inf],
+            "z": [math.inf, -math.inf],
+        }
+
+        for row in reader:
+            n_nodes += 1
+            if "defect_label" in row:
+                labels[row["defect_label"]] += 1
+            for axis in ("x", "y", "z"):
+                if axis in row:
+                    value = _safe_float(row[axis])
+                    coordinate_bounds[axis][0] = min(coordinate_bounds[axis][0], value)
+                    coordinate_bounds[axis][1] = max(coordinate_bounds[axis][1], value)
+            for col in present_physics:
+                value = _safe_float(row[col])
+                maxima[col] = max(maxima.get(col, abs(value)), abs(value))
+                minima[col] = min(minima.get(col, value), value)
+                if abs(value) > 1e-12:
+                    nonzero_counts[col] += 1
+
+    displacement_nonzero = any(nonzero_counts[c] > 0 for c in present_displacement)
+    stress_nonzero = any(nonzero_counts[c] > 0 for c in present_stress)
+    physics_nonzero = any(nonzero_counts[c] > 0 for c in present_physics)
+    n_defect_nodes = sum(count for label, count in labels.items() if label not in {"0", "0.0", "healthy"})
+
+    warnings: List[str] = []
+    if missing_required:
+        warnings.append("nodes.csv missing required columns: " + ",".join(missing_required))
+    if not present_displacement:
+        warnings.append("no displacement columns present")
+    elif not displacement_nonzero:
+        warnings.append("all displacement columns are zero")
+    if not present_stress:
+        warnings.append("no stress-equivalent columns present")
+    elif not stress_nonzero:
+        warnings.append("all stress-equivalent columns are zero")
+    if present_physics and not physics_nonzero:
+        warnings.append("all physics columns are zero")
+
+    return {
+        "columns": columns,
+        "missing_required_columns": missing_required,
+        "present_physics_columns": present_physics,
+        "present_displacement_columns": present_displacement,
+        "present_stress_columns": present_stress,
+        "n_nodes": n_nodes,
+        "label_counts": dict(labels),
+        "n_defect_nodes": n_defect_nodes,
+        "nonzero_counts": dict(nonzero_counts),
+        "max_abs": maxima,
+        "min": minima,
+        "coordinate_bounds": coordinate_bounds,
+        "warnings": warnings,
+    }
+
+
+def audit_dataset(root: Path) -> Dict[str, object]:
+    sample_dirs = _discover_sample_dirs(root)
+    samples = []
+    warning_count = 0
+    total_nodes = 0
+    total_defect_nodes = 0
+    schemas: Counter[Tuple[str, ...]] = Counter()
+
+    for sample_dir in sample_dirs:
+        node_report = _audit_nodes(sample_dir)
+        n_elements, element_columns, element_warnings = _count_elements(sample_dir)
+        metadata = _read_metadata(sample_dir)
+        sample_warnings = list(node_report["warnings"]) + element_warnings
+
+        metadata_defect_nodes = metadata.get("n_defect_nodes")
+        if metadata_defect_nodes is not None:
+            try:
+                meta_count = int(float(metadata_defect_nodes))
+                if meta_count != node_report["n_defect_nodes"]:
+                    sample_warnings.append(
+                        "metadata n_defect_nodes=%d but nodes.csv has %d"
+                        % (meta_count, node_report["n_defect_nodes"])
+                    )
+            except ValueError:
+                sample_warnings.append("metadata n_defect_nodes is not numeric")
+
+        if metadata.get("defect_type", "healthy") != "healthy" and node_report["n_defect_nodes"] == 0:
+            sample_warnings.append("defective metadata but zero defect-labeled nodes")
+
+        total_nodes += int(node_report["n_nodes"])
+        total_defect_nodes += int(node_report["n_defect_nodes"])
+        warning_count += len(sample_warnings)
+        schemas[tuple(node_report["columns"])] += 1
+
+        samples.append(
+            {
+                "sample": str(sample_dir.relative_to(root)),
+                "metadata": metadata,
+                "nodes": node_report,
+                "n_elements": n_elements,
+                "element_columns": element_columns,
+                "warnings": sample_warnings,
+            }
+        )
+
+    return {
+        "root": str(root),
+        "n_samples": len(samples),
+        "total_nodes": total_nodes,
+        "total_defect_nodes": total_defect_nodes,
+        "warning_count": warning_count,
+        "schema_count": len(schemas),
+        "schemas": [{"columns": list(k), "n_samples": v} for k, v in schemas.items()],
+        "samples": samples,
+    }
+
+
+def _write_markdown(report: Dict[str, object], output: Path) -> None:
+    lines = [
+        "# Dataset Reliability Audit",
+        "",
+        "| Item | Value |",
+        "|---|---:|",
+        f"| Root | `{report['root']}` |",
+        f"| Samples | {report['n_samples']} |",
+        f"| Total nodes | {report['total_nodes']} |",
+        f"| Total defect nodes | {report['total_defect_nodes']} |",
+        f"| Distinct node schemas | {report['schema_count']} |",
+        f"| Warning count | {report['warning_count']} |",
+        "",
+        "## Samples",
+        "",
+        "| Sample | Nodes | Elements | Defect nodes | Labels | Warnings |",
+        "|---|---:|---:|---:|---|---|",
+    ]
+    for sample in report["samples"]:
+        nodes = sample["nodes"]
+        warnings = "<br>".join(sample["warnings"]) if sample["warnings"] else "-"
+        labels = ", ".join(f"{k}:{v}" for k, v in sorted(nodes["label_counts"].items()))
+        lines.append(
+            "| `{sample}` | {n_nodes} | {n_elements} | {n_defect} | {labels} | {warnings} |".format(
+                sample=sample["sample"],
+                n_nodes=nodes["n_nodes"],
+                n_elements=sample["n_elements"],
+                n_defect=nodes["n_defect_nodes"],
+                labels=labels,
+                warnings=warnings,
+            )
+        )
+    lines.append("")
+    output.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit FEM CSV dataset reliability")
+    parser.add_argument("roots", nargs="+", type=Path, help="Dataset roots to audit")
+    parser.add_argument("--json", type=Path, default=None, help="Write JSON report")
+    parser.add_argument("--markdown", type=Path, default=None, help="Write Markdown report for the first root")
+    parser.add_argument("--fail-on-warning", action="store_true", help="Exit non-zero if warnings are found")
+    args = parser.parse_args()
+
+    reports = [audit_dataset(root) for root in args.roots]
+    if args.json:
+        payload = reports[0] if len(reports) == 1 else {"reports": reports}
+        args.json.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    if args.markdown:
+        _write_markdown(reports[0], args.markdown)
+
+    for report in reports:
+        print(
+            "{root}: samples={n_samples} nodes={total_nodes} defect_nodes={total_defect_nodes} "
+            "schemas={schema_count} warnings={warning_count}".format(**report)
+        )
+        for sample in report["samples"]:
+            if sample["warnings"]:
+                print("  - %s" % sample["sample"])
+                for warning in sample["warnings"]:
+                    print("    * " + warning)
+
+    if args.fail_on_warning and any(report["warning_count"] for report in reports):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a lightweight, reproducible audit for the FEM→CSV→graph data pipeline to ensure generated datasets are physically and numerically credible before model experiments.
- Capture a structured investigation of candidate mesh/Neural-Operator variants (MeshGraphNet/Transolver/LinearNO/etc.) to guide short-term backbone choices for fixed-mesh defect classification. 
- Prevent wasted experiments on corrupted or mismatched samples by adding gating checks and clear dataset acceptance criteria. 

### Description

- Add `scripts/audit_dataset_reliability.py`, a dependency-light CLI auditor that discovers sample folders containing `nodes.csv`, validates required columns, checks physics columns for non-zero values, compares `metadata.csv` counts, counts elements, aggregates schema distributions, and can emit JSON/Markdown reports and fail CI with `--fail-on-warning`.
- Add `docs/DATA_GENERATION_VALIDITY_RESEARCH.md`, a comprehensive guide that formalizes the DOE→Abaqus→ODB→CSV→graph pipeline, defines per-stage gates, dataset acceptance criteria (including minimum defect-node thresholds), V&V/UQ recommendations, and a phased roadmap for dataset credibility and external validation. 
- Add `MESHGRAPHNET_VARIANTS.md`, a short design memo listing prioritized mesh/Neural-Operator model families (MGN-T, Transolver, LinearNO, PGOT, PIORF, GINO/GNO, X-MeshGraphNet, etc.) and an experimental plan for ablation and lightweight global processors compatible with the existing `train.py` API. 

### Testing

- Executed the auditor with `python scripts/audit_dataset_reliability.py dataset_output dataset_realistic --json /tmp/dataset_audit.json` which produced a JSON report and console summary and exited with code 0. 
- The audit run reported `dataset_output` as a pipeline-example with schema mismatches and sparse defect labeling, and `dataset_realistic` as healthy-only samples with zero defect nodes, matching the documented findings. 
- The script was also exercised to write a Markdown report via the `--markdown` option and to surface per-sample warnings for CI gating, and those runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2468d5da5083239a4d4479a1997032)