### PR TITLE
docs: CLAUDE.md 更新 + GitHub Pages ロードマップページ

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy GitHub Pages
+
+# docs/ を GitHub Pages へ自動デプロイ。
+# main への push（docs 変更時）または手動実行でトリガー。
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行は最新のみ（進行中デプロイはキャンセルせず完了させる）
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        # enablement:true で Pages 未設定でも自動有効化
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload docs/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,40 +1,120 @@
 # CLAUDE.md — Project Instructions for Claude Code
 
 ## Project
-JAXA H3 ロケット CFRP/Al-Honeycomb フェアリングの GNN-SHM (構造ヘルスモニタリング)。
-デボンディング欠陥検出を Graph Neural Network で実現する研究プロジェクト。
+JAXA H3 ロケット CFRP/Al-Honeycomb フェアリングの **GNN-SHM**（構造ヘルスモニタリング）研究プロジェクト。
+2025年 H3 F8 事故で顕在化した CFRP/Al ハニカム界面の**デボンディング（skin-core 剥離）欠陥検出**を、
+FEM（Abaqus）で生成した応答データ上の **Graph Neural Network** で実現する。
 
-## Pipeline
-```
-generate_doe.py → generate_fairing_dataset.py (Abaqus CAE)
-  → extract_odb_results.py (Abaqus Python) → build_graph.py → prepare_ml_data.py → train.py
-```
+研究は単一の検出タスクを超えて、複数の研究ラインに拡張済み（下記「Research Lines」参照）。
 
-## Environment
-- Abaqus 2024 (Python 3.10.5 embedded)
-- PyTorch 2.10.0, PyG 2.7.0 (pip, pyenv miniconda3)
-- GPU: 24GB x 4
-- Abaqus 実行は `abaqus_work/` から: `abaqus cae noGUI=...`
-- ODB 抽出は: `abaqus python src/extract_odb_results.py`
-
-## Key Directories
-- `src/` — メインコード (generate, extract, build_graph, train)
-- `scripts/` — 検証・可視化スクリプト
-- `wiki_repo/` — GitHub Wiki ソース (images/ 含む)
-- `dataset_realistic_25mm_100/` — 現行データセット (N=100)
-- `data/processed_*/` — PyG 前処理済みデータ
-- `runs/` — 学習ログ (TensorBoard)
-
-## Communication
-- 日本語で会話する
-- まず1つ生成して確認してから丁寧に進める
-
-## Figures
-- 図・ラベルは英語で作成する（Fig. 1, Figure 1 等）
+## Communication / Working Style
+- **日本語で会話する**
+- まず1つ生成して確認してから丁寧に進める（バッチ生成や大量変更の前に1サンプルで検証）
+- 図・ラベルは**英語**で作成する（`Fig. 1`, `Figure 1` 等）
 
 ## Git / PR Rules
-- PR の body に "Generated with Claude Code" を書かない
-- コミットメッセージは日本語OK、Co-Authored-By は付ける
+- PR の body に "Generated with Claude Code" を**書かない**
+- コミットメッセージは日本語OK、`Co-Authored-By` は付ける
+- 開発ブランチ指定がある場合はそれに従う（指定外ブランチへ push しない）
 
-## Data (34-dim Node Features)
-位置・幾何(10) + 変位(4) + 温度(1) + 応力(5) + 熱応力(1) + ひずみ(3) + 繊維配向(3) + 積層構成(5) + 境界フラグ(2) = 34次元
+## Environment
+- **Abaqus 2024**（埋め込み Python 3.10.5）— FEM 生成・ODB 抽出に使用
+- **PyTorch 2.x / PyG 2.x**（pyenv miniconda3, pip 管理）— GNN 学習に使用
+- GPU: 24GB × 4
+- Abaqus 実行は `abaqus_work/` から: `abaqus cae noGUI=...`
+- ODB 抽出は: `abaqus python src/extract_odb_results.py`
+- クラスタ: PBS/Torque（`qsub`、`scripts/dispatch_parallel.sh` 等）。`Job-*.o<id>` / `.e<id>` は再生成可能ログ（gitignore 済み）
+
+### 依存関係インストール
+```bash
+pip install -r requirements-gnn.txt        # メイン（GNN 学習スタック = core + torch + PyG）
+pip install -r requirements-quantum.txt    # 任意（Qiskit, 量子 GNN）
+pip install -r requirements-fem-alt.txt    # 任意（FEniCS / JAX-FEM 代替 FEM）
+```
+`pyproject.toml` の optional-extras（`gnn` / `quantum` / `fem` / `dev`）でも同等。
+
+## Primary Pipeline（静的 GNN 欠陥検出）
+```
+generate_doe.py → generate_fairing_dataset.py (Abaqus CAE) / run_batch.py
+  → extract_odb_results.py (Abaqus Python)
+  → build_graph.py → prepare_ml_data.py
+  → train.py → evaluate.py / predict_api.py
+```
+
+### よく使うコマンド
+```bash
+# 軽量サニティチェック（Abaqus/GPU/学習なし — H3 spec 検証 + pytest）
+./scripts/reproduce_core.sh        # = make reproduce
+
+# テストのみ / spec 検証のみ
+make test                          # pytest tests/ -q
+make validate                      # python scripts/validate_h3_specs.py
+
+# 学習（必ず src/ から実行）
+cd src && python train.py --arch gat --data_dir ../dataset/processed --epochs 200 --cross_val 5
+
+# 推論 API
+MODEL_CHECKPOINT=runs/<run>/best_model.pt uvicorn predict_api:app --port 8000
+
+# 学習結果の比較
+python scripts/compare_model_results.py
+```
+
+`train.py` の主な引数: `--arch {gcn,gat,gatv2,gin,sage,lgsta,meshgnn,gps,multiscale,transolver}`,
+`--task {node_cls,multitask}`, `--loss {weighted_ce,focal}`, `--sampler {full_graph,defect_centric}`,
+`--cross_val N`, `--multi_gpu`, 物理正則化 `--physics_lambda_*`。
+
+## Code Conventions（重要）
+1. **学習スクリプトは `src/` から実行する** — import は bare（`from models import ...`）。
+   pytest は `pyproject.toml` で `pythonpath=["src"]` を設定済み。
+2. **コミットしないもの**: `runs/`, `dataset_*/`, `dataset_output*/`, `data/`, `*.odb`,
+   `doe_*.json`, `figures/`, LaTeX/Abaqus/クラスタの scratch（`.gitignore` 参照）。
+3. **Abaqus/FEM バッチは重い** — 軽量 reproduce では実行しない。
+4. **pre-commit**: ruff（`--fix`）+ 各種フック。`src|scripts|tests` 対象。
+   ```bash
+   pip install pre-commit && pre-commit install
+   ```
+5. **CI**（`.github/workflows/ci.yml`）: CPU PyTorch + core deps で H3 spec 検証 + pytest。
+6. **Wiki 同期**: `.github/workflows/sync-wiki.yml` が `wiki_repo/` を GitHub Wiki に反映。
+
+## Data — 34-dim Node Features（静的解析）
+位置・幾何(10) + 変位(4) + 温度(1) + 応力(5) + 熱応力(1) + ひずみ(3) + 繊維配向(3) + 積層構成(5) + 境界フラグ(2) = **34次元**
+（GW センサグラフは別スキーマ。`build_gw_graph.py` 参照）
+
+## Key Directories
+- `src/` — メインコード（生成・抽出・グラフ構築・学習・モデル定義）
+  - `src/prad/` — PI-GraphMAE 自己教師あり事前学習 + 蒸留（PRAD ライン）
+  - `src/vt/` — H3 Virtual Twin（6DOF 飛行 orchestrator, 推進・空力・空力加熱）
+- `scripts/` — 検証・可視化・解析・論文図・バッチ dispatch（200+ ファイル）
+- `docs/` — 設計/検証ドキュメント（`ARCHITECTURE.md` が pipeline 概要）
+- `wiki_repo/` — GitHub Wiki ソース（`images/` 含む）
+- `dataset_*/`, `data/processed_*/` — データセット & PyG 前処理済み（gitignore）
+- `runs/` — 学習ログ（TensorBoard, checkpoints, gitignore）
+- `results/` — 公開可能な評価成果物（図・JSON・HTML ダッシュボード）
+- `experiments/` — `quantum/`, `uq/` 実験
+- `papers/` — 文献 & 参照リポジトリ clone（`papers/repos/` は内部 gitignore）
+- `portfolio/` — 半導体企業別ポートフォリオ資料（本研究と独立）
+
+## Research Lines（src/ 内の主要サブ研究）
+| ライン | 主なエントリ | 目的 |
+|--------|------------|------|
+| **静的 GNN 検出** | `train.py`, `models.py`, `build_graph.py` | 曲率対応グラフ + GAT/GCN/GIN/SAGE で node 単位欠陥検出 |
+| **FEM 生成** | `generate_fairing_dataset.py`, `generate_realistic_dataset.py`, `run_batch.py` | Abaqus H3 フェアリング + 熱荷重/デボンド欠陥 |
+| **Guided-Wave (GW)** | `generate_guided_wave.py`, `generate_gw_fairing.py`, `build_gw_graph.py`, `train_gw.py`, `train_gw_stgnn.py` | 弾性波センサ時刻歴 → グラフ → SHM 分類 |
+| **2段/3段 SHM** | `fairing_stage2.py`, `run_two_stage_pipeline.py` | Stage-1 検出 → Stage-2 特性同定 → Stage-3 予後（flight clearance） |
+| **ドメイン適応 / sim2real** | `domain_adapt.py`, `payload_da_gw.py`, `prototype_dann.py`, `scripts/*ogw*` | FEM→実測ギャップ補正、OGW（Open Guided Waves）conformal 検出 |
+| **PRAD（自己教師+蒸留）** | `src/prad/train_mae.py`, `src/prad/distill_fno2gnn.py`, `src/prad/finetune_distilled.py` | PI-GraphMAE 事前学習 → FNO 物理知識を GNN へ蒸留 |
+| **代理モデル（surrogate）** | `train_fno*.py`, `models_fno*.py`, `prototype_deeponet.py`, `prototype_pinn.py`, `mifno_gw.py` | FNO / DeepONet / PINN で FEM 高速化 |
+| **UQ（不確かさ定量化）** | `pce_driver.py`, `pce_advanced.py`, `reliability_analysis.py`, `uncertainty.py` | PCE / 信頼性解析 |
+| **基盤モデル** | `anomalygfm_shm.py`, `chronos_shm.py`, `benchmark_foundation.py`, `gpn_shm.py` | AnomalyGFM / Chronos-2 / Poseidon・DPOT ベンチ |
+| **フェアリング分離動力学** | `generate_fairing_separation.py`, `build_separation_graph.py`, `extract_separation_results.py` | Abaqus/Explicit 分離機構（破断ボルト・火工品） |
+| **Virtual Twin** | `src/vt/orchestrator.py` | T-0→SECO 全フェーズ 6DOF 飛行統合シミュレーション |
+| **量子** | `models_quantum.py`, `train_quantum.py`, `train_quantum_node.py` | 量子 GNN プロトタイプ（任意依存） |
+
+## Docs Map
+- `docs/ARCHITECTURE.md` — pipeline データフロー + モジュール層
+- `docs/ZENODO.md`, `CITATION.cff`, `.zenodo.json` — アーカイブ / 引用
+- `AGENTS.md` — AI エージェント向け簡易エントリ
+- `README.md` — 公開向け概要 + Quick Start
+- `wiki_repo/Home.md` — フル索引・ステータス・ナビゲーション
+- `ROADMAP.md`, `LITERATURE_REVIEW.md`, `MESHGRAPHNET_VARIANTS.md`, `TEMPERATURE_ROBUSTNESS.md` ほか — 研究メモ

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,343 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GNN-SHM Roadmap — H3 Fairing → Cryogenic Tank</title>
+<meta name="description" content="GNN-SHM research roadmap: from JAXA H3 CFRP fairing debonding detection to cryogenic hydrogen-tank integrity monitoring.">
+<style>
+  :root{
+    --bg:#f4f6f9; --surface:#ffffff; --surface-2:#eef2f7;
+    --ink:#0f1720; --muted:#5b6875; --line:#d7dee7;
+    --accent:#1f6feb; --cryo:#0995b4; --amber:#b7791f;
+    --good:#158a66; --prog:#1f6feb; --plan:#b7791f;
+    --grid:rgba(31,111,235,.06);
+    --shadow:0 1px 2px rgba(15,23,32,.06),0 8px 24px rgba(15,23,32,.05);
+  }
+  @media (prefers-color-scheme:dark){
+    :root{
+      --bg:#0a0f16; --surface:#111a24; --surface-2:#0d141d;
+      --ink:#e7eef6; --muted:#8b9aa9; --line:#1e2a38;
+      --accent:#4d9bff; --cryo:#38c6e0; --amber:#e0a83a;
+      --good:#2fbf94; --prog:#4d9bff; --plan:#e0a83a;
+      --grid:rgba(77,155,255,.07);
+      --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+    }
+  }
+  :root[data-theme="light"]{
+    --bg:#f4f6f9; --surface:#ffffff; --surface-2:#eef2f7;
+    --ink:#0f1720; --muted:#5b6875; --line:#d7dee7;
+    --accent:#1f6feb; --cryo:#0995b4; --amber:#b7791f;
+    --good:#158a66; --prog:#1f6feb; --plan:#b7791f;
+    --grid:rgba(31,111,235,.06);
+    --shadow:0 1px 2px rgba(15,23,32,.06),0 8px 24px rgba(15,23,32,.05);
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0f16; --surface:#111a24; --surface-2:#0d141d;
+    --ink:#e7eef6; --muted:#8b9aa9; --line:#1e2a38;
+    --accent:#4d9bff; --cryo:#38c6e0; --amber:#e0a83a;
+    --good:#2fbf94; --prog:#4d9bff; --plan:#e0a83a;
+    --grid:rgba(77,155,255,.07);
+    --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+  }
+
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{
+    margin:0; background:var(--bg); color:var(--ink);
+    font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    line-height:1.6; -webkit-font-smoothing:antialiased;
+    background-image:linear-gradient(var(--grid) 1px,transparent 1px),
+                     linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+    background-size:44px 44px;
+  }
+  .wrap{max-width:1080px;margin:0 auto;padding:clamp(28px,5vw,72px) clamp(20px,4vw,40px)}
+  .eyebrow{
+    font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--accent);font-weight:600;
+  }
+
+  /* theme toggle */
+  .toggle{position:fixed;top:14px;right:14px;z-index:10;
+    font-family:ui-monospace,monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;
+    background:var(--surface);color:var(--muted);border:1px solid var(--line);border-radius:20px;
+    padding:7px 13px;cursor:pointer;box-shadow:var(--shadow)}
+  .toggle:hover{color:var(--ink)}
+  .toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  header{border-bottom:1px solid var(--line);padding-bottom:34px;margin-bottom:44px}
+  h1{
+    font-size:clamp(30px,5vw,50px);line-height:1.04;margin:14px 0 12px;
+    font-weight:800;letter-spacing:-.02em;text-wrap:balance;max-width:16ch;
+  }
+  h1 .arrow{color:var(--cryo)}
+  .lede{font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:60ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:10px 22px;margin-top:22px;
+        font-family:ui-monospace,monospace;font-size:12.5px;color:var(--muted)}
+  .meta b{color:var(--ink);font-weight:600}
+  .legend{display:flex;flex-wrap:wrap;gap:8px 18px;margin-top:22px;
+          font-family:ui-monospace,monospace;font-size:12px;text-transform:uppercase;letter-spacing:.06em}
+  .dot{display:inline-flex;align-items:center;gap:7px;color:var(--muted)}
+  .dot::before{content:"";width:9px;height:9px;border-radius:50%;background:var(--c)}
+
+  section{margin:56px 0}
+  h2{font-size:clamp(20px,2.6vw,26px);font-weight:750;letter-spacing:-.01em;margin:8px 0 4px}
+  .sub{color:var(--muted);margin:0 0 24px;max-width:62ch}
+
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:14px}
+  .card{
+    background:var(--surface);border:1px solid var(--line);border-radius:12px;
+    padding:16px 16px 15px;box-shadow:var(--shadow);position:relative;overflow:hidden;
+  }
+  .card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--c,var(--accent))}
+  .card h3{margin:0 0 5px;font-size:15.5px;font-weight:680;letter-spacing:-.01em;padding-left:4px}
+  .card p{margin:0;font-size:13px;color:var(--muted);padding-left:4px}
+  .card .files{margin-top:9px;font-family:ui-monospace,monospace;font-size:11px;color:var(--accent);padding-left:4px;word-break:break-all}
+  .tag{position:absolute;top:14px;right:14px;font-family:ui-monospace,monospace;font-size:10px;
+       letter-spacing:.08em;text-transform:uppercase;padding:2px 7px;border-radius:20px;font-weight:600;
+       color:var(--c);border:1px solid color-mix(in srgb,var(--c) 40%,transparent);
+       background:color-mix(in srgb,var(--c) 12%,transparent)}
+
+  .track{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+  .phase{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:20px 18px;box-shadow:var(--shadow)}
+  .phase.mid{border-color:color-mix(in srgb,var(--cryo) 55%,var(--line));
+             background:linear-gradient(180deg,color-mix(in srgb,var(--cryo) 8%,var(--surface)),var(--surface))}
+  .phase .when{font-family:ui-monospace,monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+  .phase .htitle{font-size:17px;font-weight:720;margin:6px 0 2px;letter-spacing:-.01em}
+  .phase.mid .htitle{color:var(--cryo)}
+  .phase ul{margin:12px 0 0;padding-left:0;list-style:none;display:flex;flex-direction:column;gap:9px}
+  .phase li{font-size:13.5px;color:var(--ink);padding-left:20px;position:relative}
+  .phase li::before{content:"";position:absolute;left:0;top:8px;width:8px;height:8px;border-radius:2px;
+                    background:var(--accent);transform:rotate(45deg)}
+  .phase.mid li::before{background:var(--cryo)}
+  .phase.far li::before{background:var(--amber)}
+  .newpill{display:inline-block;font-family:ui-monospace,monospace;font-size:10px;font-weight:700;
+           letter-spacing:.1em;color:#fff;background:var(--cryo);padding:2px 8px;border-radius:20px;margin-left:8px;vertical-align:middle}
+
+  .tablewrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow);background:var(--surface)}
+  table{border-collapse:collapse;width:100%;min-width:560px;font-size:13.5px}
+  caption{text-align:left;font-family:ui-monospace,monospace;font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+          color:var(--muted);padding:13px 16px 0}
+  th,td{text-align:left;padding:12px 16px;vertical-align:top;border-bottom:1px solid var(--line)}
+  thead th{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600;font-family:ui-monospace,monospace}
+  thead th.tank{color:var(--cryo)}
+  tbody tr:last-child td{border-bottom:none}
+  td.rowlab{font-weight:640;color:var(--muted);white-space:nowrap}
+  td.tank{color:var(--ink);background:color-mix(in srgb,var(--cryo) 6%,transparent)}
+
+  .assets{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:22px}
+  .abox{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:18px;box-shadow:var(--shadow)}
+  .abox h4{margin:0 0 10px;font-size:13px;font-family:ui-monospace,monospace;letter-spacing:.08em;text-transform:uppercase}
+  .abox.reuse h4{color:var(--good)} .abox.build h4{color:var(--cryo)}
+  .abox ul{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:7px}
+  .abox li{font-size:13.5px}
+  .abox code{font-family:ui-monospace,monospace;font-size:12px;color:var(--accent)}
+
+  .steps{counter-reset:s;display:flex;flex-direction:column;gap:2px;margin-top:8px}
+  .step{display:grid;grid-template-columns:auto 1fr;gap:16px;padding:16px 0;border-bottom:1px solid var(--line)}
+  .step:last-child{border-bottom:none}
+  .step .n{counter-increment:s;font-family:ui-monospace,monospace;font-size:13px;font-weight:700;color:var(--cryo);
+           border:1px solid color-mix(in srgb,var(--cryo) 45%,transparent);border-radius:8px;width:34px;height:34px;
+           display:flex;align-items:center;justify-content:center}
+  .step .n::before{content:counter(s,decimal-leading-zero)}
+  .step h4{margin:2px 0 3px;font-size:15px;font-weight:660}
+  .step p{margin:0;font-size:13.5px;color:var(--muted)}
+  .step code{font-family:ui-monospace,monospace;font-size:12px;color:var(--accent)}
+
+  .decide{background:var(--surface-2);border:1px solid var(--line);border-radius:14px;padding:24px clamp(18px,3vw,28px);margin-top:20px}
+  .decide h2{margin-top:0}
+  .opts{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:16px}
+  .opt{background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:15px}
+  .opt .k{font-family:ui-monospace,monospace;font-weight:700;color:var(--accent);font-size:13px}
+  .opt p{margin:6px 0 0;font-size:13px;color:var(--muted)}
+
+  footer{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);
+          font-family:ui-monospace,monospace;font-size:11.5px;color:var(--muted);
+          display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+  footer a{color:var(--accent);text-decoration:none}
+  footer a:hover{text-decoration:underline}
+
+  @media (prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
+  @media (max-width:760px){
+    .track,.opts{grid-template-columns:1fr}
+    .assets{grid-template-columns:1fr}
+  }
+</style>
+</head>
+<body>
+<button class="toggle" id="themeToggle" type="button" aria-label="Toggle color theme">◑ Theme</button>
+<div class="wrap">
+  <header>
+    <div class="eyebrow">JAXA H3 · GNN-SHM · Research Roadmap</div>
+    <h1>From fairing debonding <span class="arrow">→</span> LH2 tank integrity</h1>
+    <p class="lede">A geometry-aware Graph Neural Network SHM stack, proven on the H3 CFRP/Al-honeycomb payload fairing, extended toward the next structural target: the cryogenic hydrogen tank.</p>
+    <div class="meta">
+      <span><b>Structure:</b> CFRP/Al-HC sandwich</span>
+      <span><b>Method:</b> FEM (Abaqus) → PyG GNN</span>
+      <span><b>Motivation:</b> H3 F8 accident (2025)</span>
+    </div>
+    <div class="legend">
+      <span class="dot" style="--c:var(--good)">Shipped</span>
+      <span class="dot" style="--c:var(--prog)">In progress</span>
+      <span class="dot" style="--c:var(--plan)">Planned</span>
+    </div>
+  </header>
+
+  <section>
+    <div class="eyebrow">01 — Established capabilities</div>
+    <h2>What the stack already does</h2>
+    <p class="sub">Nine research lines are implemented on the fairing today. These are the reusable assets the hydrogen-tank line inherits.</p>
+    <div class="grid">
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Static GNN detection</h3><p>Curvature-aware graphs, node-level debond classification.</p>
+        <div class="files">train.py · models.py · build_graph.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Guided-Wave GNN</h3><p>Sensor time-histories → spatio-temporal graphs → SHM classification.</p>
+        <div class="files">build_gw_graph.py · train_gw_stgnn.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>2/3-stage SHM</h3><p>Detect → characterize severity → prognosis (flight clearance).</p>
+        <div class="files">fairing_stage2.py · run_two_stage_pipeline.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Domain adaptation</h3><p>sim2real bridge; OGW split-conformal detection with FPR guarantee.</p>
+        <div class="files">domain_adapt.py · payload_da_gw.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Temperature robustness</h3><p>Operating-point shift handling — directly relevant to cryogenics.</p>
+        <div class="files">TEMPERATURE_ROBUSTNESS.md</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>PRAD</h3><p>PI-GraphMAE self-supervised pretrain → FNO-to-GNN physics distillation.</p>
+        <div class="files">src/prad/</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Surrogates &amp; UQ</h3><p>FNO / DeepONet / PINN acceleration; PCE reliability analysis.</p>
+        <div class="files">train_fno*.py · pce_driver.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Foundation models</h3><p>AnomalyGFM / Chronos-2 / Poseidon · DPOT benchmarks.</p>
+        <div class="files">anomalygfm_shm.py · chronos_shm.py</div></div>
+      <div class="card" style="--c:var(--good)"><span class="tag" style="--c:var(--good)">Shipped</span>
+        <h3>Virtual Twin</h3><p>T-0 → SECO full-phase 6DOF flight integration.</p>
+        <div class="files">src/vt/orchestrator.py</div></div>
+    </div>
+  </section>
+
+  <section>
+    <div class="eyebrow">02 — Three horizons</div>
+    <h2>Timeline</h2>
+    <p class="sub">Near-term closes out the fairing story; mid-term opens the hydrogen-tank line; long-term generalizes to composite cryotanks and full digital-twin integration.</p>
+    <div class="track">
+      <div class="phase near">
+        <div class="when">Near · Fairing wrap-up</div>
+        <div class="htitle">Finish &amp; publish</div>
+        <ul>
+          <li>Merge CLAUDE.md docs update (PR #36)</li>
+          <li>FEM↔OGW matched-design real-data evaluation</li>
+          <li>Conformal detection under temperature shift — paper figures</li>
+        </ul>
+      </div>
+      <div class="phase mid">
+        <div class="when">Mid · New structural target</div>
+        <div class="htitle">Hydrogen tank <span class="newpill">NEW</span></div>
+        <ul>
+          <li>Al-Li tank FEM: internal pressure + cryogenic thermal stress</li>
+          <li>Defects: weld flaws, thermal-cycle microcracks, insulation debond</li>
+          <li>Reuse GW + GNN + domain adaptation; conformal leak-risk guarantee</li>
+        </ul>
+      </div>
+      <div class="phase far">
+        <div class="when">Long · Generalization</div>
+        <div class="htitle">Cryotank &amp; twin</div>
+        <ul>
+          <li>Composite (CFRP) LH2 cryotank: microcrack + permeability SHM</li>
+          <li>Virtual Twin coupling — airframe + tank health in one model</li>
+          <li>Validation on JAXA PSS / cryogenic test data</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="eyebrow" style="color:var(--cryo)">03 — Deep dive</div>
+    <h2>The hydrogen-tank extension</h2>
+    <p class="sub">The H3 LH2/LOX tanks are Al-Li welded structures at cryogenic temperature (LH2 −253 °C). The damage physics differ from the fairing, but the pipeline transfers with targeted additions.</p>
+
+    <div class="tablewrap">
+      <table>
+        <caption>Fig. 1 — Fairing (existing) vs. hydrogen tank (proposed)</caption>
+        <thead><tr><th></th><th>Fairing — existing</th><th class="tank">Hydrogen tank — proposed</th></tr></thead>
+        <tbody>
+          <tr><td class="rowlab">Structure</td><td>CFRP / Al-honeycomb sandwich</td><td class="tank">Al-Li welded tank (future: CFRP cryotank)</td></tr>
+          <tr><td class="rowlab">Primary defects</td><td>Skin–core debonding</td><td class="tank">Weld flaws · thermal-cycle microcracks · insulation debond · H-embrittlement</td></tr>
+          <tr><td class="rowlab">Loading</td><td>Thermal (CTE) + static</td><td class="tank">Internal pressure + cryogenic thermal stress + fill-cycle fatigue</td></tr>
+          <tr><td class="rowlab">Key physics</td><td>Curvature · laminate stacking</td><td class="tank">Cryogenic property shift · leak paths · permeability</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="assets">
+      <div class="abox reuse">
+        <h4>Reuse as-is</h4>
+        <ul>
+          <li>GW + GNN — Lamb-wave propagation on tank walls</li>
+          <li>Domain adaptation — fairing→tank, ambient→cryogenic shift</li>
+          <li>Temperature-robustness framework — cryo is the extreme operating point</li>
+          <li>Conformal detection &amp; UQ — go/no-go reliability guarantee</li>
+        </ul>
+      </div>
+      <div class="abox build">
+        <h4>Build new</h4>
+        <ul>
+          <li>Al-Li cylinder FEM with pressure + cryo thermal stress</li>
+          <li>Weld-line &amp; thermal-cycle crack defect models</li>
+          <li>Node features: cryogenic properties + pressure flag</li>
+          <li>Leak-path / permeability labeling for prognosis</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="eyebrow">04 — First moves</div>
+    <h2>How the tank line starts</h2>
+    <div class="steps">
+      <div class="step"><div class="n"></div><div>
+        <h4>FEM generation</h4>
+        <p>Adapt <code>generate_*</code> into an Al-Li cylinder (internal pressure + cryogenic thermal stress) with weld-line and thermal-cycle crack defects. Validate on <b>one sample first</b> before batching.</p></div></div>
+      <div class="step"><div class="n"></div><div>
+        <h4>Graph construction</h4>
+        <p>Reuse <code>build_graph.py</code> / <code>build_gw_graph.py</code>; add cryogenic material properties and an internal-pressure flag to node features.</p></div></div>
+      <div class="step"><div class="n"></div><div>
+        <h4>Training</h4>
+        <p>Run existing <code>train.py</code> / <code>train_gw.py</code> unchanged — verify on one sample, then scale to the full batch.</p></div></div>
+      <div class="step"><div class="n"></div><div>
+        <h4>sim2real + guarantee</h4>
+        <p>Bridge ambient test data → cryogenic operation with the existing DA toolkit; wrap leak-risk decisions in split-conformal FPR guarantees.</p></div></div>
+    </div>
+  </section>
+
+  <div class="decide">
+    <div class="eyebrow">Decision needed</div>
+    <h2>Where to start?</h2>
+    <p class="sub" style="margin-bottom:0">Pick a first move — or propose your own. Each is independently shippable.</p>
+    <div class="opts">
+      <div class="opt"><span class="k">A · Docs first</span><p>Add the hydrogen-tank line formally to ROADMAP.md / CLAUDE.md.</p></div>
+      <div class="opt"><span class="k">B · Code first</span><p>Prototype the tank FEM generator, validated on one sample.</p></div>
+      <div class="opt"><span class="k">C · Method memo</span><p>Extend the temperature-robustness framework to cryogenics as a technical note.</p></div>
+    </div>
+  </div>
+
+  <footer>
+    <span>GNN-SHM · JAXA H3 CFRP fairing → cryogenic tank</span>
+    <span><a href="https://github.com/keisuke58/Payload_gnn">github.com/keisuke58/Payload_gnn</a></span>
+  </footer>
+</div>
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('themeToggle');
+    function cur(){ if(root.dataset.theme) return root.dataset.theme;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'; }
+    btn.addEventListener('click',function(){
+      root.dataset.theme = cur()==='dark' ? 'light' : 'dark';
+    });
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
2つのドキュメント変更を含みます。

### 1. `CLAUDE.md` を現行リポジトリ状態に更新
既存の重要な指示（日本語で会話・図は英語・PR/コミット規約・34次元ノード特徴）を維持しつつ、リポジトリの拡張を反映。
- **Research Lines** を新設: 静的 GNN 検出、Guided-Wave (GW)、2/3段 SHM、ドメイン適応/sim2real（OGW conformal）、PRAD、代理モデル（FNO/DeepONet/PINN）、UQ（PCE）、基盤モデル（AnomalyGFM/Chronos-2）、フェアリング分離動力学、Virtual Twin、量子 GNN
- **Code Conventions**（`src/` 実行・pre-commit・CI・Wiki 同期）、依存関係、よく使うコマンド、ディレクトリ構成、Docs Map を最新化

### 2. GitHub Pages 用ロードマップページ（`docs/index.html`）
フェアリング SHM の現状 → **水素タンク (LH2) 拡張**のロードマップを図入りで公開。
- 実装済み9研究ラインのステータスグリッド / 3期タイムライン / 水素タンク比較表（Fig.1）/ 着手ステップ
- スタンドアロン HTML（外部依存なし・light/dark 対応・横スクロールなし）＋ `docs/.nojekyll`
- **有効化手順**: リポジトリ Settings → Pages → Source: *Deploy from a branch* → Branch: `main` / Folder: `/docs`（本 PR マージ後）。公開 URL は `https://keisuke58.github.io/Payload_gnn/`

## 確認
- HTML パース OK、図ラベルは英語（プロジェクト規約準拠）
- ドキュメントのみの変更（コード影響なし）